### PR TITLE
CMIP5 setup included

### DIFF
--- a/Scripts/Common/execWPS.sh
+++ b/Scripts/Common/execWPS.sh
@@ -67,13 +67,13 @@ if [[ ${RUNPYWPS} == 1 ]]
 		#cp ${NOCLOBBER} -P "${INIDIR}/MIROC5_rcp85_2085_pointer_local_full.validate.nc" "${WORKDIR}/CMIP5data.validate.nc"      # copy the validate file used by cdb_query
     cp ${NOCLOBBER} -P "${INIDIR}/init" "${WORKDIR}"     #copy the initial step data
 		cp ${NOCLOBBER} -P "${BINDIR}/unCMIP5.ncl" "${BINDIR}/unccsm.exe" "${WORKDIR}"    # copy the executables
-    find -maxdepth 1 -name "*validate*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/CMIP5data.validate.nc" \;
+    find ./meta -maxdepth 1 -name "*validate*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/CMIP5data.validate.nc" \;
 		#cp ${NOCLOBBER} -P "${INIDIR}/orog_fx_MIROC5_rcp85_r0i0p0.nc" "${WORKDIR}/orog_file.nc"      # copy the coordinate files used by unCMIP5.ncl
-    find -maxdepth 1 -name "*orog*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/orog_file.nc" \;
+    find ./meta -maxdepth 1 -name "*orog*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/orog_file.nc" \;
 		#cp ${NOCLOBBER} -P "${INIDIR}/sftlf_fx_MIROC5_rcp85_r0i0p0.nc" "${WORKDIR}/sftlf_file.nc"      
-    find -maxdepth 1 -name "*sftlf*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/sftlf_file.nc" \;
+    find ./meta -maxdepth 1 -name "*sftlf*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/sftlf_file.nc" \;
 		#cp ${NOCLOBBER} -P "${INIDIR}/MIROC5_ocn2atm_linearweight.nc" "${WORKDIR}/ocn2atmweight_file.nc"      
-    find -maxdepth 1 -name "*linearweight*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/ocn2atmweight_file.nc" \;
+    find ./meta -maxdepth 1 -name "*linearweight*" -exec cp ${NOCLOBBER} -P {} "${WORKDIR}/ocn2atmweight_file.nc" \;
 		
 	elif [[ "${DATATYPE}" == 'ERA-I' ]]; then
     # CFSR Reanalysis Data
@@ -126,7 +126,7 @@ if [[ ${RUNPYWPS} == 1 ]]
 		mv "${PYDATA}"/* "${METDATA}"
 		rm -r "${PYDATA}"
     fi
-
+    
     # finish
     
     echo

--- a/Scripts/Setup/setupExperiment.sh
+++ b/Scripts/Setup/setupExperiment.sh
@@ -181,7 +181,10 @@ if [[ -z "${CASETYPE}" ]]; then
 fi
 
 # boundary data definition for WPS
-if [[ "${DATATYPE}" == 'CESM' ]]; then
+if [[ "${DATATYPE}" == 'CMIP5' ]]; then
+  POPMAP=${POPMAP:-'map_gx1v6_to_fv0.9x1.25_aave_da_090309.nc'} # ocean grid definition
+  METGRIDTBL=${METGRIDTBL:-'METGRID.TBL.CESM'}
+elif [[ "${DATATYPE}" == 'CESM' ]]; then
   POPMAP=${POPMAP:-'map_gx1v6_to_fv0.9x1.25_aave_da_090309.nc'} # ocean grid definition
   METGRIDTBL=${METGRIDTBL:-'METGRID.TBL.CESM'}
 # elif [[ "${DATATYPE}" == 'CCSM' ]]; then
@@ -211,7 +214,7 @@ fi # $FLAKE
 # but there are many versions of WRF...
 if [[ -z "$WRFBLD" ]]; then
   # GCM or reanalysis with current I/O version
-  if [[ "${DATATYPE}" == 'CESM' ]] || [[ "${DATATYPE}" == 'CCSM' ]]; then
+  if [[ "${DATATYPE}" == 'CESM' ]] || [[ "${DATATYPE}" == 'CCSM' ]] || [[ "${DATATYPE}" == 'CMIP5' ]]; then
     WRFBLD="Clim-${IO}" # variable GHG scenarios and no leap-years
     LLEAP='--noleap' # option for Python script to omit leap days
   elif [[ "${DATATYPE}" == 'ERA-I' ]] || [[ "${DATATYPE}" == 'CFSR' ]] || [[ "${DATATYPE}" == 'NARR' ]]; then
@@ -355,7 +358,7 @@ mkdir -p "${RUNDIR}/meta"
 cd "${RUNDIR}/meta"
 ln -sf "${WPSSRC}/geogrid/${GEOGRIDTBL}" 'GEOGRID.TBL'
 ln -sf "${WPSSRC}/metgrid/${METGRIDTBL}" 'METGRID.TBL'
-if [[ "${DATATYPE}" == 'CESM' ]] || [[ "${DATATYPE}" == 'CCSM' ]]; then
+if [[ "${DATATYPE}" == 'CESM' ]] || [[ "${DATATYPE}" == 'CCSM' ]] || [[ "${DATATYPE}" == 'CMIP5' ]]; then
   ln -sf "${WRFTOOLS}/misc/data/${POPMAP}"
 elif [[ "${DATATYPE}" == 'CFSR' ]]; then
   ln -sf "${WPSSRC}/ungrib/Variable_Tables/${VTABLE_PLEV}" 'Vtable.CFSR_plev'
@@ -372,6 +375,9 @@ if [[ "${DATATYPE}" == 'CESM' ]] || [[ "${DATATYPE}" == 'CCSM' ]]; then
   ln -sf "${DATADIR}/atm/hist/" 'atm' # atmosphere
   ln -sf "${DATADIR}/lnd/hist/" 'lnd' # land surface
   ln -sf "${DATADIR}/ice/hist/" 'ice' # sea ice
+elif [[ "${DATATYPE}" == 'CMIP5' ]]; then
+  rm -f 'init'
+  ln -sf "${DATADIR}/" 'init'  # initial file directory
 elif [[ "${DATATYPE}" == 'CFSR' ]]; then
   rm -f 'plev' 'srfc'
   ln -sf "${DATADIR}/plev/" 'plev' # pressure level date (3D, 0.5 deg)
@@ -421,6 +427,9 @@ ln -sf "${METEXE}"
 ln -sf "${REALEXE}"
 if [[ "${DATATYPE}" == 'CESM' ]] || [[ "${DATATYPE}" == 'CCSM' ]]; then
   ln -sf "${WRFTOOLS}/NCL/unccsm.ncl"
+  ln -sf "${WRFTOOLS}/bin/${WPSSYS}/unccsm.exe"
+elif  [[ "${DATATYPE}" == 'CMIP5' ]]; then
+  ln -sf "${WRFTOOLS}/NCL/unCMIP5.ncl"
   ln -sf "${WRFTOOLS}/bin/${WPSSYS}/unccsm.exe"
 else
   ln -sf "${UNGRIBEXE}"
@@ -640,6 +649,11 @@ echo
 echo "Remaining tasks:"
 echo " * review meta data and namelists"
 echo " * edit run scripts, if necessary,"
+if  [[ "${DATATYPE}" == 'CMIP5' ]]; then
+  echo " * copy the necessary meta files for CMIP5 into the meta folder"
+  echo " * These file includes the ocn2atm, orog, sftlf files for grid info"
+  echo " * copy the cdb_query CMIP5 validate file into the meta folder"
+fi
 echo
 # count number of broken links
 CNT=0


### PR DESCRIPTION
included DATASET=CMIP5 option in setupexperiment.sh

Note that the meta files are not going to be copied by the script, and manual work is still needed. This is the case that the grid definition files are a small portion to all meta files of CMIP5 experiment, and the validation file could have a highly varying name. I have added a note to remind copying those files at the end of the setup script.