### PR TITLE
Add sleep to execWRF.sh

### DIFF
--- a/Scripts/Common/execWRF.sh
+++ b/Scripts/Common/execWRF.sh
@@ -161,6 +161,7 @@ if [[ ${RUNWRF} == 1 ]]
     echo "TASKS=${TASKS}"
     echo "${HYBRIDRUN} ./wrf.exe"
     echo
+    sleep 1m
     # launch
     eval "time -p ${HYBRIDRUN} ./wrf.exe"
     wait # wait for all threads to finish


### PR DESCRIPTION
Add a sleep line to ensure wrf.exe could read restart file properly.